### PR TITLE
update for next go release, Go 1

### DIFF
--- a/memcache.go
+++ b/memcache.go
@@ -102,7 +102,7 @@ func (memc *Memcache) Get(key string) (value []byte, flags int, err os.Error) {
 			break
 		}
 		if err != nil {
-			return
+			return nil, 0, err
 		}
 		n += i
 		if n >= l {


### PR DESCRIPTION
Go now disallows return without arguments when any
of the output parameters have been shadowed.
Here's a small patch to fix the one case of that in gomemcache.
