### PR TITLE
Tcp unix support

### DIFF
--- a/gomemcache.go
+++ b/gomemcache.go
@@ -57,13 +57,21 @@ var (
 	NotFoundError   = errors.New("memcache: not found")
 )
 
-func Connect(host string) (*Memcache, error) {
-	return Dial(host)
+func Connect(host string, port int) (*Memcache, error) {
+	var network, addr string
+	if port == 0 {
+		network = "unix"
+		addr = host
+	} else {
+		network = "tcp"
+		addr = host + ":" + strconv.Itoa(port)
+	}
+	return Dial(network, addr)
 }
 
-func Dial(addr string) (memc *Memcache, err error) {
+func Dial(network, addr string) (memc *Memcache, err error) {
 	memc = new(Memcache)
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial(network, addr)
 	if err != nil {
 		return
 	}

--- a/gomemcache_test.go
+++ b/gomemcache_test.go
@@ -1,3 +1,8 @@
+/**
+ * Run two following commands on the background before this test.
+ * $ memcached
+ * $ memcached -s /tmp/memcached.sock -a 0755
+ */
 package gomemcache
 
 import (
@@ -17,8 +22,29 @@ const (
 
 var memc *Memcache
 
-func TestDial(t *testing.T) {
-	c, err := Dial("127.0.0.1:11211")
+func TestDial_TCP(t *testing.T) {
+	c, err := Dial("tcp", "127.0.0.1:11211")
+	assertNoError(t, err)
+	err = c.Close()
+	assertNoError(t, err)
+}
+
+func TestDial_UNIX(t *testing.T) {
+	c, err := Dial("unix", "/tmp/memcached.sock")
+	assertNoError(t, err)
+	err = c.Close()
+	assertNoError(t, err)
+}
+
+func testConnect_TCP(t *testing.T) {
+	c, err := Connect("127.0.0.1", 11211)
+	assertNoError(t, err)
+	err = c.Close()
+	assertNoError(t, err)
+}
+
+func testConnect_UNIX(t *testing.T) {
+	c, err := Connect("/tmp/memcached.sock", 0)
 	assertNoError(t, err)
 	err = c.Close()
 	assertNoError(t, err)


### PR DESCRIPTION
If you want to use this with UNIX domain socket, you can use like a following source code.
On a UNIX domain socket, port is 0.

```
mc, err := gomemcache.Connect("/path/to/memcached.sock", 0)
```
