### PR TITLE
Add support for darner message queue

### DIFF
--- a/gomemcache.go
+++ b/gomemcache.go
@@ -143,7 +143,7 @@ func (memc *Memcache) readValue(reader *bufio.Reader, key string) (value []byte,
 		return
 	}
 	a := strings.Split(strings.TrimSpace(line), " ")
-	if len(a) != 4 || a[0] != "VALUE" || a[1] != key {
+	if len(a) != 4 || a[0] != "VALUE" {
 		if line == "END\r\n" {
 			err = NotFoundError
 		} else {


### PR DESCRIPTION
Darner message queue usues memcache protocol.
https://github.com/wavii/darner

It supports transactional reads, for example:

```
val, fl, err := memc.Get("task/open")
// Perform job
_, _, _ = memc.Get("task/close")
```

This PR fixes ReadError that raises because
server response doesn't have "/open" suffix in key name.

Key "task/open" != "task" in server response.

Example: 

```
telnet *** 22133
Escape character is '^]'.
get task/peek
VALUE task 0 24
task_content
END
get task/open
VALUE task 0 24
task_content
END
get task/close
END
```
